### PR TITLE
add support for nginx solo mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- add nginx solo support, see [sample config for nginx solo mode](config/nginx-solo.conf.erb) and [README](README.md)
+
 ## [0.8] - 2018-09-13
 ### Changed
 - update nginx to 1.15.3

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ web: bin/start-nginx bundle exec unicorn -c config/unicorn.rb
 
 ### nginx Solo Mode
 
-nginx-buildpack provides a command named `bin/start-nginx-solo`. It does not take any arguments, it only starts nginx if you don't run a app server on the same Dyno.
-
+nginx-buildpack provides a command named `bin/start-nginx-solo`. This is for you if you don't want to run an additional app server on the Dyno.
+This mode requires you to put a `config/nginx.conf.erb` in your app code. You can start by coping the [sample config for nginx solo mode](config/nginx-solo.conf.erb).
 For example, to get NGINX and Unicorn up and running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,13 +43,24 @@ at=info method=GET path=/ host=salty-earth-7125.herokuapp.com request_id=e2c79e8
 
 ### Language/App Server Agnostic
 
-Nginx-buildpack provides a command named `bin/start-nginx` this command takes another command as an argument. You must pass your app server's startup command to `start-nginx`.
+nginx-buildpack provides a command named `bin/start-nginx` this command takes another command as an argument. You must pass your app server's startup command to `start-nginx`.
 
 For example, to get NGINX and Unicorn up and running:
 
 ```bash
 $ cat Procfile
 web: bin/start-nginx bundle exec unicorn -c config/unicorn.rb
+```
+
+### nginx Solo Mode
+
+nginx-buildpack provides a command named `bin/start-nginx-solo`. It does not take any arguments, it only starts nginx if you don't run a app server on the same Dyno.
+
+For example, to get NGINX and Unicorn up and running:
+
+```bash
+$ cat Procfile
+web: bin/start-nginx-solo
 ```
 
 ### Setting the Worker Processes

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,8 @@ nginx_version=$(./bin/nginx-$STACK -V 2>&1 | head -1 | awk '{ print $NF }')
 echo "-----> nginx-buildpack: Installed ${nginx_version} to app/bin"
 cp bin/start-nginx "$1/bin/"
 echo '-----> nginx-buildpack: Added start-nginx to app/bin'
+cp bin/start-nginx-solo "$1/bin/"
+echo '-----> nginx-buildpack: Added start-nginx-solo to app/bin'
 
 mkdir -p "$1/config"
 

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -4,69 +4,69 @@ psmgr=/tmp/nginx-buildpack-wait
 rm -f $psmgr
 mkfifo $psmgr
 
-#Evaluate config to get $PORT
+# Evaluate config to get $PORT
 erb config/nginx.conf.erb > config/nginx.conf
 
 n=1
 while getopts :f option ${@:1:2}
 do
-    case "${option}"
-    in
-        f) FORCE=$OPTIND; n=$((n+1));;
-    esac
+  case "${option}"
+  in
+    f) FORCE=$OPTIND; n=$((n+1));;
+  esac
 done
 
-#Initialize log directory.
+# Initialize log directory.
 mkdir -p logs/nginx
 touch logs/nginx/access.log logs/nginx/error.log
 echo 'buildpack=nginx at=logs-initialized'
 
-#Start log redirection.
+# Start log redirection.
 (
-    # Redirect NGINX logs to stdout.
-    tail -qF -n 0 logs/nginx/*.log
-    echo 'logs' >$psmgr
+  # Redirect nginx logs to stdout.
+  tail -qF -n 0 logs/nginx/*.log
+  echo 'logs' >$psmgr
 ) &
 
-#Start App Server
+# Start App Server
 (
-    # Take the command passed to this bin and start it.
-    # E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
-    COMMAND=${@:$n}
-    echo "buildpack=nginx at=start-app cmd=$COMMAND"
-    $COMMAND
-    echo 'app' >$psmgr
+  # Take the command passed to this bin and start it.
+  # E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
+  COMMAND=${@:$n}
+  echo "buildpack=nginx at=start-app cmd=$COMMAND"
+  $COMMAND
+  echo 'app' >$psmgr
 ) &
 
 if [[ -z "$FORCE" ]]
 then
-    FILE="/tmp/app-initialized"
+  FILE="/tmp/app-initialized"
 
-    # We block on app-initialized so that when NGINX binds to $PORT
-    # are app is ready for traffic.
-    while [[ ! -f "$FILE" ]]
-    do
-        echo 'buildpack=nginx at=app-initialization'
-        sleep 1
-    done
-    echo 'buildpack=nginx at=app-initialized'
+  # We block on app-initialized so that when nginx binds to $PORT
+  # are app is ready for traffic.
+  while [[ ! -f "$FILE" ]]
+  do
+    echo 'buildpack=nginx at=app-initialization'
+    sleep 1
+  done
+  echo 'buildpack=nginx at=app-initialized'
 fi
 
-#Start NGINX
+# Start nginx
 (
-    # We expect nginx to run in foreground.
-    # We also expect a socket to be at /tmp/nginx.socket.
-    echo 'buildpack=nginx at=nginx-start'
-    bin/nginx -p . -c config/nginx.conf
-    echo 'nginx' >$psmgr
+  # We expect nginx to run in foreground.
+  # We also expect a socket to be at /tmp/nginx.socket.
+  echo 'buildpack=nginx at=nginx-start'
+  bin/nginx -p . -c config/nginx.conf
+  echo 'nginx' >$psmgr
 ) &
 
-#This read will block the process waiting on a msg to be put into the fifo.
-#If any of the processes defined above should exit,
-#a msg will be put into the fifo causing the read operation
-#to un-block. The process putting the msg into the fifo
-#will use it's process name as a msg so that we can print the offending
-#process to stdout.
+# This read will block the process waiting on a msg to be put into the fifo.
+# If any of the processes defined above should exit,
+# a msg will be put into the fifo causing the read operation
+# to un-block. The process putting the msg into the fifo
+# will use it's process name as a msg so that we can print the offending
+# process to stdout.
 read exit_process <$psmgr
 echo "buildpack=nginx at=exit process=$exit_process"
 exit 1

--- a/bin/start-nginx-solo
+++ b/bin/start-nginx-solo
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+psmgr=/tmp/nginx-buildpack-wait
+rm -f $psmgr
+mkfifo $psmgr
+
+# Evaluate config to get $PORT
+erb config/nginx.conf.erb > config/nginx.conf
+
+n=1
+while getopts :f option ${@:1:2}
+do
+  case "${option}"
+  in
+    f) FORCE=$OPTIND; n=$((n+1));;
+  esac
+done
+
+# Initialize log directory.
+mkdir -p logs/nginx
+touch logs/nginx/access.log logs/nginx/error.log
+echo 'buildpack=nginx at=logs-initialized'
+
+# Start log redirection.
+(
+  # Redirect nginx logs to stdout.
+  tail -qF -n 0 logs/nginx/*.log
+  echo 'logs' >$psmgr
+) &
+
+# Start nginx
+(
+  #We expect nginx to run in foreground.
+  #We also expect a socket to be at /tmp/nginx.socket.
+  echo 'buildpack=nginx at=nginx-start'
+  bin/nginx -p . -c config/nginx.conf
+  echo 'nginx' >$psmgr
+) &
+
+# This read will block the process waiting on a msg to be put into the fifo.
+# If any of the processes defined above should exit,
+# a msg will be put into the fifo causing the read operation
+# to un-block. The process putting the msg into the fifo
+# will use it's process name as a msg so that we can print the offending
+# process to stdout.
+read exit_process <$psmgr
+echo "buildpack=nginx at=exit process=$exit_process"
+exit 1

--- a/config/nginx-solo-sample.conf.erb
+++ b/config/nginx-solo-sample.conf.erb
@@ -1,0 +1,37 @@
+daemon off;
+# Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+
+events {
+  use epoll;
+  accept_mutex on;
+  worker_connections 1024;
+}
+
+http {
+  gzip on;
+  gzip_comp_level 2;
+  gzip_min_length 512;
+
+  server_tokens off;
+
+  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+  access_log logs/nginx/access.log l2met;
+  error_log logs/nginx/error.log;
+
+  include mime.types;
+  default_type application/octet-stream;
+  sendfile on;
+
+  # Must read the body in 5 seconds.
+  client_body_timeout <%= ENV['NGINX_CLIENT_BODY_TIMEOUT'] || 5 %>;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name _;
+    keepalive_timeout 5;
+    client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
+
+    root /app/public; # path to your app
+  }
+}


### PR DESCRIPTION
there is a demand to just run nginx without any app server, this cuts out the launch of the app server from `start-nginx` and provides a different entry point for that `start-nginx-solo`